### PR TITLE
Specify bucket prefix on commandline

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,10 @@ Create a "targets" file that looks like:
 <host>:<port>
 <host>:<port>
 ```
-then just `go build smoketcp.go` and `./smoketcp <statsd_host>:<statsd_port>` and boom.
+then just `go build smoketcp.go` and `./smoketcp <statsd_host>:<statsd_port> <bucket_prefix>` and boom.
+
+#Ex: 
+`./smoketcp statsd.example.com:8125 Location.for.smokeping.values`
 
 Every second it tests every entry (in parallel), and reports errors and time-to-connection to statsd.
 Statsd then aggregates across the flushInterval (in our case 60s) and stores in graphite per target the errors rate,

--- a/smoketcp.go
+++ b/smoketcp.go
@@ -1,82 +1,77 @@
 package main
 
 import (
-  "fmt"
-  "github.com/cactus/go-statsd-client/statsd"
-  "io/ioutil"
-  "net"
-  "os"
-  "strings"
-  "time"
+	"fmt"
+	"github.com/cactus/go-statsd-client/statsd"
+	"io/ioutil"
+	"net"
+	"os"
+	"strings"
+	"time"
 )
 
-
 func dieIfError(err error) {
-  if err != nil {
-    fmt.Fprintf(os.Stderr, "Fatal error: %s\n", err.Error())
-    os.Exit(1)
-  }
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Fatal error: %s\n", err.Error())
+		os.Exit(1)
+	}
 }
-
 
 func doEvery(d time.Duration, s *statsd.Client, bucket string) {
-  process_targets(s, bucket)
-  for _ = range time.Tick(d) {
-    process_targets(s, bucket)
-  }
+	process_targets(s, bucket)
+	for _ = range time.Tick(d) {
+		process_targets(s, bucket)
+	}
 }
-
 
 func process_targets(s *statsd.Client, bucket string) {
-  content, err := ioutil.ReadFile("targets")
-  if err != nil {
-    fmt.Println("couldn't open targets file")
-    return
-  }
-  targets := strings.Split(string(content), "\n")
-  for _, target := range targets {
-    if len(target) < 1 {
-      continue
-    }
-    go test(target, s, bucket)
-  }
+	content, err := ioutil.ReadFile("targets")
+	if err != nil {
+		fmt.Println("couldn't open targets file")
+		return
+	}
+	targets := strings.Split(string(content), "\n")
+	for _, target := range targets {
+		if len(target) < 1 {
+			continue
+		}
+		go test(target, s, bucket)
+	}
 }
-
 
 func test(target string, s *statsd.Client, bucket string) {
-  tuple := strings.Split(target, ":")
-  host := tuple[0]
-  port := tuple[1]
-  hostport := strings.Join([]string{host, port}, ":")
+	tuple := strings.Split(target, ":")
+	host := tuple[0]
+	port := tuple[1]
+	hostport := strings.Join([]string{host, port}, ":")
 
-  pre := time.Now()
-  conn, err := net.Dial("tcp", hostport)
-  if err != nil {
-    fmt.Println("connect error", target)
-    s.Inc(fmt.Sprintf("%s.smokeping.%s.%s.dial_failed", bucket, host, port), 1, 1)
-    return
-  }
-  duration := time.Since(pre)
-  subhost := strings.Replace(host, ".", "_", -1)
-  ms := int64(duration / time.Millisecond)
-  fmt.Printf("%s.smokeping.%s.%s.duration %d\n", bucket, subhost, port, ms)
-  s.Timing(fmt.Sprintf("%s.smokeping.%s.%s", bucket, host, port), ms, 1)
-  conn.Close()
+	pre := time.Now()
+	conn, err := net.Dial("tcp", hostport)
+	if err != nil {
+		fmt.Println("connect error", target)
+		s.Inc(fmt.Sprintf("%s.smokeping.%s.%s.dial_failed", bucket, host, port), 1, 1)
+		return
+	}
+	duration := time.Since(pre)
+	subhost := strings.Replace(host, ".", "_", -1)
+	ms := int64(duration / time.Millisecond)
+	fmt.Printf("%s.smokeping.%s.%s.duration %d\n", bucket, subhost, port, ms)
+	s.Timing(fmt.Sprintf("%s.smokeping.%s.%s", bucket, host, port), ms, 1)
+	conn.Close()
 }
 
-
 func main() {
-  if len(os.Args) < 3 {
-    fmt.Println("Usage: smoketcp <statsd_host>:<statsd_port> <bucket_prefix>")
-    fmt.Println("\nEx: smoketcp statsd.cashstar.net:8125 PROD.us-east-1.dw1")
-    os.Exit(1)
-  }
+	if len(os.Args) < 3 {
+		fmt.Println("Usage: smoketcp <statsd_host>:<statsd_port> <bucket_prefix>")
+		fmt.Println("\nEx: smoketcp statsd.cashstar.net:8125 PROD.us-east-1.dw1")
+		os.Exit(1)
+	}
 
-  hostname, err := os.Hostname()
-  dieIfError(err)
-  s, err := statsd.New(os.Args[1], fmt.Sprintf("smoketcp.%s", hostname))
-  dieIfError(err)
-  bucket := os.Args[2]
-  defer s.Close()
-  doEvery(time.Second, s, bucket)
+	hostname, err := os.Hostname()
+	dieIfError(err)
+	s, err := statsd.New(os.Args[1], fmt.Sprintf("smoketcp.%s", hostname))
+	dieIfError(err)
+	bucket := os.Args[2]
+	defer s.Close()
+	doEvery(time.Second, s, bucket)
 }

--- a/smoketcp.go
+++ b/smoketcp.go
@@ -63,7 +63,7 @@ func test(target string, s *statsd.Client, bucket string) {
 func main() {
 	if len(os.Args) < 3 {
 		fmt.Println("Usage: smoketcp <statsd_host>:<statsd_port> <bucket_prefix>")
-		fmt.Println("\nEx: smoketcp statsd.cashstar.net:8125 PROD.us-east-1.dw1")
+		fmt.Println("\nEx: smoketcp statsd.example.com:8125 Location.for.smokeping.values")
 		os.Exit(1)
 	}
 

--- a/smoketcp.go
+++ b/smoketcp.go
@@ -1,70 +1,82 @@
 package main
 
 import (
-	"fmt"
-	"github.com/cactus/go-statsd-client/statsd"
-	"io/ioutil"
-	"net"
-	"os"
-	"strings"
-	"time"
+  "fmt"
+  "github.com/cactus/go-statsd-client/statsd"
+  "io/ioutil"
+  "net"
+  "os"
+  "strings"
+  "time"
 )
 
+
 func dieIfError(err error) {
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Fatal error: %s\n", err.Error())
-		os.Exit(1)
-	}
-}
-func doEvery(d time.Duration, f func(*statsd.Client), s *statsd.Client) {
-	f(s)
-	for _ = range time.Tick(d) {
-		f(s)
-	}
+  if err != nil {
+    fmt.Fprintf(os.Stderr, "Fatal error: %s\n", err.Error())
+    os.Exit(1)
+  }
 }
 
-func process_targets(s *statsd.Client) {
-	content, err := ioutil.ReadFile("targets")
-	if err != nil {
-		fmt.Println("couldn't open targets file")
-		return
-	}
-	targets := strings.Split(string(content), "\n")
-	for _, target := range targets {
-		if len(target) < 1 {
-			continue
-		}
-		go test(target, s)
-	}
+
+func doEvery(d time.Duration, s *statsd.Client, bucket string) {
+  process_targets(s, bucket)
+  for _ = range time.Tick(d) {
+    process_targets(s, bucket)
+  }
 }
-func test(target string, s *statsd.Client) {
-	pre := time.Now()
-	conn, err := net.Dial("tcp", target)
-	if err != nil {
-		fmt.Println("connect error", target)
-		s.Inc(fmt.Sprintf("error.%s.dial_failed", target), 1, 1)
-		return
-	}
-	duration := time.Since(pre)
-	tuple := strings.Split(target, ":")
-	host := strings.Replace(tuple[0], ".", "_", -1)
-	port := tuple[1]
-	ms := int64(duration / time.Millisecond)
-	fmt.Printf("%s.%s.duration %d\n", host, port, ms)
-	s.Timing(fmt.Sprintf("dial.%s.%s", host, port), ms, 1)
-	conn.Close()
+
+
+func process_targets(s *statsd.Client, bucket string) {
+  content, err := ioutil.ReadFile("targets")
+  if err != nil {
+    fmt.Println("couldn't open targets file")
+    return
+  }
+  targets := strings.Split(string(content), "\n")
+  for _, target := range targets {
+    if len(target) < 1 {
+      continue
+    }
+    go test(target, s, bucket)
+  }
 }
+
+
+func test(target string, s *statsd.Client, bucket string) {
+  tuple := strings.Split(target, ":")
+  host := tuple[0]
+  port := tuple[1]
+  hostport := strings.Join([]string{host, port}, ":")
+
+  pre := time.Now()
+  conn, err := net.Dial("tcp", hostport)
+  if err != nil {
+    fmt.Println("connect error", target)
+    s.Inc(fmt.Sprintf("%s.smokeping.%s.%s.dial_failed", bucket, host, port), 1, 1)
+    return
+  }
+  duration := time.Since(pre)
+  subhost := strings.Replace(host, ".", "_", -1)
+  ms := int64(duration / time.Millisecond)
+  fmt.Printf("%s.smokeping.%s.%s.duration %d\n", bucket, subhost, port, ms)
+  s.Timing(fmt.Sprintf("%s.smokeping.%s.%s", bucket, host, port), ms, 1)
+  conn.Close()
+}
+
 
 func main() {
-	if len(os.Args) == 1 {
-		fmt.Println("Usage: smoketcp <statsd_host>:<statsd_port>")
-		os.Exit(1)
-	}
+  if len(os.Args) < 3 {
+    fmt.Println("Usage: smoketcp <statsd_host>:<statsd_port> <bucket_prefix>")
+    fmt.Println("\nEx: smoketcp statsd.cashstar.net:8125 PROD.us-east-1.dw1")
+    os.Exit(1)
+  }
 
-	hostname, err := os.Hostname()
-	dieIfError(err)
-	s, err := statsd.Dial(os.Args[1], fmt.Sprintf("smoketcp.%s", hostname))
-	dieIfError(err)
-	defer s.Close()
-	doEvery(time.Second, process_targets, s)
+  hostname, err := os.Hostname()
+  dieIfError(err)
+  s, err := statsd.New(os.Args[1], fmt.Sprintf("smoketcp.%s", hostname))
+  dieIfError(err)
+  bucket := os.Args[2]
+  defer s.Close()
+  doEvery(time.Second, s, bucket)
 }

--- a/smoketcp.go
+++ b/smoketcp.go
@@ -49,14 +49,14 @@ func test(target string, s *statsd.Client, bucket string) {
 	conn, err := net.Dial("tcp", hostport)
 	if err != nil {
 		fmt.Println("connect error", target)
-		s.Inc(fmt.Sprintf("%s.smokeping.%s.%s.dial_failed", bucket, host, port), 1, 1)
+		s.Inc(fmt.Sprintf("%s.%s.%s.dial_failed", bucket, host, port), 1, 1)
 		return
 	}
 	duration := time.Since(pre)
 	subhost := strings.Replace(host, ".", "_", -1)
 	ms := int64(duration / time.Millisecond)
-	fmt.Printf("%s.smokeping.%s.%s.duration %d\n", bucket, subhost, port, ms)
-	s.Timing(fmt.Sprintf("%s.smokeping.%s.%s", bucket, host, port), ms, 1)
+	fmt.Printf("%s.%s.%s.duration %d\n", bucket, subhost, port, ms)
+	s.Timing(fmt.Sprintf("%s.%s.%s", bucket, host, port), ms, 1)
 	conn.Close()
 }
 
@@ -69,7 +69,7 @@ func main() {
 
 	hostname, err := os.Hostname()
 	dieIfError(err)
-	s, err := statsd.New(os.Args[1], fmt.Sprintf("smoketcp.%s", hostname))
+	s, err := statsd.Dial(os.Args[1], fmt.Sprintf("smoketcp.%s", hostname))
 	dieIfError(err)
 	bucket := os.Args[2]
 	defer s.Close()


### PR DESCRIPTION
This modification allows you to specify the bucket to send stats to on the command line, useful for people like me who don't like the default!
