### PR TITLE
Use flags on commandline

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,10 @@ Create a "targets" file that looks like:
 <host>:<port>
 <host>:<port>
 ```
-then just `go build smoketcp.go` and `./smoketcp <statsd_host>:<statsd_port>` and boom.
+then just `go build smoketcp.go` and `./smoketcp <statsd_host>:<statsd_port> <bucket_prefix>` and boom.
+
+#Ex: 
+`./smoketcp statsd.example.com:8125 Location.for.smokeping.values`
 
 Every second it tests every entry (in parallel), and reports errors and time-to-connection to statsd.
 Statsd then aggregates across the flushInterval (in our case 60s) and stores in graphite per target the errors rate,

--- a/README.md
+++ b/README.md
@@ -12,11 +12,16 @@ Create a "targets" file that looks like:
 ```
 
 then just:
-  `go build smoketcp.go`
-and:
-  `./smoketcp --statsd_host <statsd_host> --statsd_port <statsd_port> --bucket <bucket_prefix>`
+```
+go build smoketcp.go
+```
 
-The available flags are available with --help:
+and:
+```
+./smoketcp --statsd_host <statsd_host> --statsd_port <statsd_port> --bucket <bucket_prefix>
+```
+
+The flags are available with --help:
 ```
 ./smoketcp --help
 Usage of ./smoketcp:

--- a/README.md
+++ b/README.md
@@ -11,7 +11,10 @@ Create a "targets" file that looks like:
 <host>:<port>
 ```
 
-then just `go build smoketcp.go` and `./smoketcp --statsd_host <statsd_host> --statsd_port <statsd_port> --bucket <bucket_prefix>`
+then just:
+  `go build smoketcp.go`
+and:
+  `./smoketcp --statsd_host <statsd_host> --statsd_port <statsd_port> --bucket <bucket_prefix>`
 
 The available flags are available with --help:
 ```
@@ -25,9 +28,6 @@ Usage of ./smoketcp:
   -target_file="targets": File containing the list of targets, ex: server1:80
 ```
 
-#Ex: 
-`./smoketcp -- statsd_host statsd.example.com --statsd_port 8125 --bucket Location.for.smokeping.values --interval 1 --target_file /etc/smoketcp_targets.txt`
-
-Every second it tests every entry (in parallel), and reports errors and time-to-connection to statsd.
+Every ten seconds (configurable with --interval) it tests every entry (in parallel), and reports errors and time-to-connection to statsd.
 Statsd then aggregates across the flushInterval (in our case 60s) and stores in graphite per target the errors rate,
 and the mean, lower, upper, upper_90 etc values.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ go build smoketcp.go
 
 and:
 ```
-./smoketcp --statsd_host <statsd_host> --statsd_port <statsd_port> --bucket <bucket_prefix>
+./smoketcp --statsdHost <statsdHost> --statsdPort <statsdPort> --bucket <bucket_prefix>
 ```
 
 The flags are available with --help:
@@ -28,9 +28,9 @@ Usage of ./smoketcp:
   -bucket="smoketcp": Graphite bucket prefix
   -debug=false: if true, turn on debugging output
   -interval=10: How often to run the tests
-  -statsd_host="localhost": Statsd Hostname
-  -statsd_port="8125": Statsd port
-  -target_file="targets": File containing the list of targets, ex: server1:80
+  -statsdHost="localhost": Statsd Hostname
+  -statsdPort="8125": Statsd port
+  -targetFile="targets": File containing the list of targets, ex: server1:80
 ```
 
 Every ten seconds (configurable with --interval) it tests every entry (in parallel), and reports errors and time-to-connection to statsd.

--- a/README.md
+++ b/README.md
@@ -10,10 +10,23 @@ Create a "targets" file that looks like:
 <host>:<port>
 <host>:<port>
 ```
-then just `go build smoketcp.go` and `./smoketcp <statsd_host>:<statsd_port> <bucket_prefix>` and boom.
+
+then just `go build smoketcp.go` and `./smoketcp --statsd_host <statsd_host> --statsd_port <statsd_port> --bucket <bucket_prefix>`
+
+The available flags are available with --help:
+```
+./smoketcp --help
+Usage of ./smoketcp:
+  -bucket="smoketcp": Graphite bucket prefix
+  -debug=false: if true, turn on debugging output
+  -interval=10: How often to run the tests
+  -statsd_host="localhost": Statsd Hostname
+  -statsd_port="8125": Statsd port
+  -target_file="targets": File containing the list of targets, ex: server1:80
+```
 
 #Ex: 
-`./smoketcp statsd.example.com:8125 Location.for.smokeping.values`
+`./smoketcp -- statsd_host statsd.example.com --statsd_port 8125 --bucket Location.for.smokeping.values --interval 1 --target_file /etc/smoketcp_targets.txt`
 
 Every second it tests every entry (in parallel), and reports errors and time-to-connection to statsd.
 Statsd then aggregates across the flushInterval (in our case 60s) and stores in graphite per target the errors rate,

--- a/smoketcp.go
+++ b/smoketcp.go
@@ -28,9 +28,9 @@ func doEvery(d time.Duration, f func(*statsd.Client, string, bool), s *statsd.Cl
 func process_targets(s *statsd.Client, target_file string, debug bool) {
 	content, err := ioutil.ReadFile(target_file)
 	if err != nil {
-    if debug {
-		  fmt.Println("couldn't open targets file: %s", target_file)
-    }
+		if debug {
+			fmt.Println("couldn't open targets file: %s", target_file)
+		}
 		return
 	}
 	targets := strings.Split(string(content), "\n")
@@ -51,28 +51,28 @@ func test(target string, s *statsd.Client, debug bool) {
 	pre := time.Now()
 	conn, err := net.Dial("tcp", target)
 	if err != nil {
-    if debug {
-		  fmt.Println("connect error", target)
+		if debug {
+			fmt.Println("connect error", target)
 		}
-    s.Inc(fmt.Sprintf("%s.%s.dial_failed", subhost, port), 1, 1)
+		s.Inc(fmt.Sprintf("%s.%s.dial_failed", subhost, port), 1, 1)
 		return
 	}
 	duration := time.Since(pre)
 	ms := int64(duration / time.Millisecond)
-  if debug {
-	  fmt.Printf("%s.%s.duration %d\n", subhost, port, ms)
-  }
+	if debug {
+		fmt.Printf("%s.%s.duration %d\n", subhost, port, ms)
+	}
 	s.Timing(fmt.Sprintf("%s.%s", subhost, port), ms, 1)
 	conn.Close()
 }
 
 func main() {
-  var statsd_host = flag.String("statsd_host", "localhost", "Statsd Hostname")
-  var statsd_port = flag.String("statsd_port", "8125", "Statsd port")
-  var bucket = flag.String("bucket", "smoketcp", "Graphite bucket prefix")
-  var target_file = flag.String("target_file", "targets", "File containing the list of targets, ex: server1:80")
-  var debug = flag.Bool("debug", false, "if true, turn on debugging output")
-  flag.Parse()
+	var statsd_host = flag.String("statsd_host", "localhost", "Statsd Hostname")
+	var statsd_port = flag.String("statsd_port", "8125", "Statsd port")
+	var bucket = flag.String("bucket", "smoketcp", "Graphite bucket prefix")
+	var target_file = flag.String("target_file", "targets", "File containing the list of targets, ex: server1:80")
+	var debug = flag.Bool("debug", false, "if true, turn on debugging output")
+	flag.Parse()
 
 	s, err := statsd.Dial(fmt.Sprintf("%s:%s", *statsd_host, *statsd_port), fmt.Sprintf("%s", *bucket))
 	dieIfError(err)

--- a/smoketcp.go
+++ b/smoketcp.go
@@ -29,7 +29,7 @@ func process_targets(s *statsd.Client, target_file string, debug bool) {
 	content, err := ioutil.ReadFile(target_file)
 	if err != nil {
 		if debug {
-			fmt.Println("couldn't open targets file: %s", target_file)
+			fmt.Println("couldn't open targets file:", target_file)
 		}
 		return
 	}
@@ -52,7 +52,7 @@ func test(target string, s *statsd.Client, debug bool) {
 	conn, err := net.Dial("tcp", target)
 	if err != nil {
 		if debug {
-			fmt.Println("connect error", target)
+			fmt.Println("connect error:", subhost, port)
 		}
 		s.Inc(fmt.Sprintf("%s.%s.dial_failed", subhost, port), 1, 1)
 		return

--- a/smoketcp.go
+++ b/smoketcp.go
@@ -18,17 +18,19 @@ func dieIfError(err error) {
 	}
 }
 
-func doEvery(d time.Duration, f func(*statsd.Client), s *statsd.Client) {
-	f(s)
+func doEvery(d time.Duration, f func(*statsd.Client, string, bool), s *statsd.Client, target_file string, debug bool) {
+	f(s, target_file, debug)
 	for _ = range time.Tick(d) {
-		f(s)
+		f(s, target_file, debug)
 	}
 }
 
-func process_targets(s *statsd.Client) {
-	content, err := ioutil.ReadFile("targets")
+func process_targets(s *statsd.Client, target_file string, debug bool) {
+	content, err := ioutil.ReadFile(target_file)
 	if err != nil {
-		fmt.Println("couldn't open targets file")
+    if debug {
+		  fmt.Println("couldn't open targets file: %s", target_file)
+    }
 		return
 	}
 	targets := strings.Split(string(content), "\n")
@@ -36,11 +38,11 @@ func process_targets(s *statsd.Client) {
 		if len(target) < 1 {
 			continue
 		}
-		go test(target, s)
+		go test(target, s, debug)
 	}
 }
 
-func test(target string, s *statsd.Client) {
+func test(target string, s *statsd.Client, debug bool) {
 	tuple := strings.Split(target, ":")
 	host := tuple[0]
 	port := tuple[1]
@@ -49,13 +51,17 @@ func test(target string, s *statsd.Client) {
 	pre := time.Now()
 	conn, err := net.Dial("tcp", target)
 	if err != nil {
-		fmt.Println("connect error", target)
-		s.Inc(fmt.Sprintf("%s.%s.dial_failed", subhost, port), 1, 1)
+    if debug {
+		  fmt.Println("connect error", target)
+		}
+    s.Inc(fmt.Sprintf("%s.%s.dial_failed", subhost, port), 1, 1)
 		return
 	}
 	duration := time.Since(pre)
 	ms := int64(duration / time.Millisecond)
-	fmt.Printf("%s.%s.duration %d\n", subhost, port, ms)
+  if debug {
+	  fmt.Printf("%s.%s.duration %d\n", subhost, port, ms)
+  }
 	s.Timing(fmt.Sprintf("%s.%s", subhost, port), ms, 1)
 	conn.Close()
 }
@@ -64,10 +70,12 @@ func main() {
   var statsd_host = flag.String("statsd_host", "localhost", "Statsd Hostname")
   var statsd_port = flag.String("statsd_port", "8125", "Statsd port")
   var bucket = flag.String("bucket", "smoketcp", "Graphite bucket prefix")
+  var target_file = flag.String("target_file", "targets", "File containing the list of targets, ex: server1:80")
+  var debug = flag.Bool("debug", false, "if true, turn on debugging output")
   flag.Parse()
 
 	s, err := statsd.Dial(fmt.Sprintf("%s:%s", *statsd_host, *statsd_port), fmt.Sprintf("%s", *bucket))
 	dieIfError(err)
 	defer s.Close()
-	doEvery(time.Second, process_targets, s)
+	doEvery(time.Second, process_targets, s, *target_file, *debug)
 }

--- a/smoketcp.go
+++ b/smoketcp.go
@@ -1,82 +1,77 @@
 package main
 
 import (
-  "fmt"
-  "github.com/cactus/go-statsd-client/statsd"
-  "io/ioutil"
-  "net"
-  "os"
-  "strings"
-  "time"
+	"fmt"
+	"github.com/cactus/go-statsd-client/statsd"
+	"io/ioutil"
+	"net"
+	"os"
+	"strings"
+	"time"
 )
 
-
 func dieIfError(err error) {
-  if err != nil {
-    fmt.Fprintf(os.Stderr, "Fatal error: %s\n", err.Error())
-    os.Exit(1)
-  }
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Fatal error: %s\n", err.Error())
+		os.Exit(1)
+	}
 }
-
 
 func doEvery(d time.Duration, s *statsd.Client, bucket string) {
-  process_targets(s, bucket)
-  for _ = range time.Tick(d) {
-    process_targets(s, bucket)
-  }
+	process_targets(s, bucket)
+	for _ = range time.Tick(d) {
+		process_targets(s, bucket)
+	}
 }
-
 
 func process_targets(s *statsd.Client, bucket string) {
-  content, err := ioutil.ReadFile("targets")
-  if err != nil {
-    fmt.Println("couldn't open targets file")
-    return
-  }
-  targets := strings.Split(string(content), "\n")
-  for _, target := range targets {
-    if len(target) < 1 {
-      continue
-    }
-    go test(target, s, bucket)
-  }
+	content, err := ioutil.ReadFile("targets")
+	if err != nil {
+		fmt.Println("couldn't open targets file")
+		return
+	}
+	targets := strings.Split(string(content), "\n")
+	for _, target := range targets {
+		if len(target) < 1 {
+			continue
+		}
+		go test(target, s, bucket)
+	}
 }
-
 
 func test(target string, s *statsd.Client, bucket string) {
-  tuple := strings.Split(target, ":")
-  host := tuple[0]
-  port := tuple[1]
-  hostport := strings.Join([]string{host, port}, ":")
+	tuple := strings.Split(target, ":")
+	host := tuple[0]
+	port := tuple[1]
+	hostport := strings.Join([]string{host, port}, ":")
 
-  pre := time.Now()
-  conn, err := net.Dial("tcp", hostport)
-  if err != nil {
-    fmt.Println("connect error", target)
-    s.Inc(fmt.Sprintf("%s.smokeping.%s.%s.dial_failed", bucket, host, port), 1, 1)
-    return
-  }
-  duration := time.Since(pre)
-  subhost := strings.Replace(host, ".", "_", -1)
-  ms := int64(duration / time.Millisecond)
-  fmt.Printf("%s.smokeping.%s.%s.duration %d\n", bucket, subhost, port, ms)
-  s.Timing(fmt.Sprintf("%s.smokeping.%s.%s", bucket, host, port), ms, 1)
-  conn.Close()
+	pre := time.Now()
+	conn, err := net.Dial("tcp", hostport)
+	if err != nil {
+		fmt.Println("connect error", target)
+		s.Inc(fmt.Sprintf("%s.smokeping.%s.%s.dial_failed", bucket, host, port), 1, 1)
+		return
+	}
+	duration := time.Since(pre)
+	subhost := strings.Replace(host, ".", "_", -1)
+	ms := int64(duration / time.Millisecond)
+	fmt.Printf("%s.smokeping.%s.%s.duration %d\n", bucket, subhost, port, ms)
+	s.Timing(fmt.Sprintf("%s.smokeping.%s.%s", bucket, host, port), ms, 1)
+	conn.Close()
 }
 
-
 func main() {
-  if len(os.Args) < 3 {
-    fmt.Println("Usage: smoketcp <statsd_host>:<statsd_port> <bucket_prefix>")
-    fmt.Println("\nEx: smoketcp statsd.cashstar.net:8125 PROD.us-east-1.dw1")
-    os.Exit(1)
-  }
+	if len(os.Args) < 3 {
+		fmt.Println("Usage: smoketcp <statsd_host>:<statsd_port> <bucket_prefix>")
+		fmt.Println("\nEx: smoketcp statsd.cashstar.net:8125 PROD.us-east-1.dw1")
+		os.Exit(1)
+	}
 
-  hostname, err := os.Hostname()
-  dieIfError(err)
-  s, err := statsd.New(os.Args[1], fmt.Sprintf("smoketcp.%s", hostname))
-  dieIfError(err)
-  bucket := os.Args[2]
-  defer s.Close()
-  doEvery(time.Second, s, bucket)
+	hostname, err := os.Hostname()
+	dieIfError(err)
+	s, err := statsd.New(os.Args[1], fmt.Sprintf("smoketcp.%s", hostname))
+	dieIfError(err)
+	bucket := os.Args[2]
+	defer s.Close()
+	doEvery(time.Second, s, bucket)
 }

--- a/smoketcp.go
+++ b/smoketcp.go
@@ -57,13 +57,13 @@ func test(target string, s *statsd.Client, debug bool) {
 		s.Inc(fmt.Sprintf("%s.%s.dial_failed", subhost, port), 1, 1)
 		return
 	}
+	conn.Close()
 	duration := time.Since(pre)
 	ms := int64(duration / time.Millisecond)
 	if debug {
 		fmt.Printf("%s.%s.duration %d\n", subhost, port, ms)
 	}
 	s.Timing(fmt.Sprintf("%s.%s", subhost, port), ms, 1)
-	conn.Close()
 }
 
 func main() {
@@ -72,10 +72,11 @@ func main() {
 	var bucket = flag.String("bucket", "smoketcp", "Graphite bucket prefix")
 	var target_file = flag.String("target_file", "targets", "File containing the list of targets, ex: server1:80")
 	var debug = flag.Bool("debug", false, "if true, turn on debugging output")
+	var interval = flag.Int("interval", 10, "How often to run the tests")
 	flag.Parse()
 
 	s, err := statsd.Dial(fmt.Sprintf("%s:%s", *statsd_host, *statsd_port), fmt.Sprintf("%s", *bucket))
 	dieIfError(err)
 	defer s.Close()
-	doEvery(time.Second, process_targets, s, *target_file, *debug)
+	doEvery(time.Duration(*interval)*time.Second, process_targets, s, *target_file, *debug)
 }

--- a/smoketcp.go
+++ b/smoketcp.go
@@ -63,7 +63,7 @@ func test(target string, s *statsd.Client, bucket string) {
 func main() {
 	if len(os.Args) < 3 {
 		fmt.Println("Usage: smoketcp <statsd_host>:<statsd_port> <bucket_prefix>")
-		fmt.Println("\nEx: smoketcp statsd.cashstar.net:8125 PROD.us-east-1.dw1")
+		fmt.Println("\nEx: smoketcp statsd.example.com:8125 Location.for.smokeping.values")
 		os.Exit(1)
 	}
 

--- a/smoketcp.go
+++ b/smoketcp.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"flag"
 	"fmt"
 	"github.com/cactus/go-statsd-client/statsd"
 	"io/ioutil"
@@ -60,13 +61,12 @@ func test(target string, s *statsd.Client) {
 }
 
 func main() {
-	if len(os.Args) < 3 {
-		fmt.Println("Usage: smoketcp <statsd_host>:<statsd_port> <bucket_prefix>")
-		fmt.Println("\nEx: smoketcp statsd.example.com:8125 Location.for.smokeping.values")
-		os.Exit(1)
-	}
+  var statsd_host = flag.String("statsd_host", "localhost", "Statsd Hostname")
+  var statsd_port = flag.String("statsd_port", "8125", "Statsd port")
+  var bucket = flag.String("bucket", "smoketcp", "Graphite bucket prefix")
+  flag.Parse()
 
-	s, err := statsd.Dial(os.Args[1], fmt.Sprintf("%s", os.Args[2]))
+	s, err := statsd.Dial(fmt.Sprintf("%s:%s", *statsd_host, *statsd_port), fmt.Sprintf("%s", *bucket))
 	dieIfError(err)
 	defer s.Close()
 	doEvery(time.Second, process_targets, s)

--- a/smoketcp.go
+++ b/smoketcp.go
@@ -1,70 +1,82 @@
 package main
 
 import (
-	"fmt"
-	"github.com/cactus/go-statsd-client/statsd"
-	"io/ioutil"
-	"net"
-	"os"
-	"strings"
-	"time"
+  "fmt"
+  "github.com/cactus/go-statsd-client/statsd"
+  "io/ioutil"
+  "net"
+  "os"
+  "strings"
+  "time"
 )
 
+
 func dieIfError(err error) {
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Fatal error: %s\n", err.Error())
-		os.Exit(1)
-	}
-}
-func doEvery(d time.Duration, f func(*statsd.Client), s *statsd.Client) {
-	f(s)
-	for _ = range time.Tick(d) {
-		f(s)
-	}
+  if err != nil {
+    fmt.Fprintf(os.Stderr, "Fatal error: %s\n", err.Error())
+    os.Exit(1)
+  }
 }
 
-func process_targets(s *statsd.Client) {
-	content, err := ioutil.ReadFile("targets")
-	if err != nil {
-		fmt.Println("couldn't open targets file")
-		return
-	}
-	targets := strings.Split(string(content), "\n")
-	for _, target := range targets {
-		if len(target) < 1 {
-			continue
-		}
-		go test(target, s)
-	}
+
+func doEvery(d time.Duration, s *statsd.Client, bucket string) {
+  process_targets(s, bucket)
+  for _ = range time.Tick(d) {
+    process_targets(s, bucket)
+  }
 }
-func test(target string, s *statsd.Client) {
-	pre := time.Now()
-	conn, err := net.Dial("tcp", target)
-	if err != nil {
-		fmt.Println("connect error", target)
-		s.Inc(fmt.Sprintf("error.%s.dial_failed", target), 1, 1)
-		return
-	}
-	duration := time.Since(pre)
-	tuple := strings.Split(target, ":")
-	host := strings.Replace(tuple[0], ".", "_", -1)
-	port := tuple[1]
-	ms := int64(duration / time.Millisecond)
-	fmt.Printf("%s.%s.duration %d\n", host, port, ms)
-	s.Timing(fmt.Sprintf("dial.%s.%s", host, port), ms, 1)
-	conn.Close()
+
+
+func process_targets(s *statsd.Client, bucket string) {
+  content, err := ioutil.ReadFile("targets")
+  if err != nil {
+    fmt.Println("couldn't open targets file")
+    return
+  }
+  targets := strings.Split(string(content), "\n")
+  for _, target := range targets {
+    if len(target) < 1 {
+      continue
+    }
+    go test(target, s, bucket)
+  }
 }
+
+
+func test(target string, s *statsd.Client, bucket string) {
+  tuple := strings.Split(target, ":")
+  host := tuple[0]
+  port := tuple[1]
+  hostport := strings.Join([]string{host, port}, ":")
+
+  pre := time.Now()
+  conn, err := net.Dial("tcp", hostport)
+  if err != nil {
+    fmt.Println("connect error", target)
+    s.Inc(fmt.Sprintf("%s.smokeping.%s.%s.dial_failed", bucket, host, port), 1, 1)
+    return
+  }
+  duration := time.Since(pre)
+  subhost := strings.Replace(host, ".", "_", -1)
+  ms := int64(duration / time.Millisecond)
+  fmt.Printf("%s.smokeping.%s.%s.duration %d\n", bucket, subhost, port, ms)
+  s.Timing(fmt.Sprintf("%s.smokeping.%s.%s", bucket, host, port), ms, 1)
+  conn.Close()
+}
+
 
 func main() {
-	if len(os.Args) == 1 {
-		fmt.Println("Usage: smoketcp <statsd_host>:<statsd_port>")
-		os.Exit(1)
-	}
+  if len(os.Args) < 3 {
+    fmt.Println("Usage: smoketcp <statsd_host>:<statsd_port> <bucket_prefix>")
+    fmt.Println("\nEx: smoketcp statsd.cashstar.net:8125 PROD.us-east-1.dw1")
+    os.Exit(1)
+  }
 
-	hostname, err := os.Hostname()
-	dieIfError(err)
-	s, err := statsd.Dial(os.Args[1], fmt.Sprintf("smoketcp.%s", hostname))
-	dieIfError(err)
-	defer s.Close()
-	doEvery(time.Second, process_targets, s)
+  hostname, err := os.Hostname()
+  dieIfError(err)
+  s, err := statsd.New(os.Args[1], fmt.Sprintf("smoketcp.%s", hostname))
+  dieIfError(err)
+  bucket := os.Args[2]
+  defer s.Close()
+  doEvery(time.Second, s, bucket)
 }

--- a/smoketcp.go
+++ b/smoketcp.go
@@ -49,14 +49,14 @@ func test(target string, s *statsd.Client, bucket string) {
 	conn, err := net.Dial("tcp", hostport)
 	if err != nil {
 		fmt.Println("connect error", target)
-		s.Inc(fmt.Sprintf("%s.smokeping.%s.%s.dial_failed", bucket, host, port), 1, 1)
+		s.Inc(fmt.Sprintf("%s.%s.%s.dial_failed", bucket, host, port), 1, 1)
 		return
 	}
 	duration := time.Since(pre)
 	subhost := strings.Replace(host, ".", "_", -1)
 	ms := int64(duration / time.Millisecond)
-	fmt.Printf("%s.smokeping.%s.%s.duration %d\n", bucket, subhost, port, ms)
-	s.Timing(fmt.Sprintf("%s.smokeping.%s.%s", bucket, host, port), ms, 1)
+	fmt.Printf("%s.%s.%s.duration %d\n", bucket, subhost, port, ms)
+	s.Timing(fmt.Sprintf("%s.%s.%s", bucket, host, port), ms, 1)
 	conn.Close()
 }
 
@@ -69,7 +69,7 @@ func main() {
 
 	hostname, err := os.Hostname()
 	dieIfError(err)
-	s, err := statsd.New(os.Args[1], fmt.Sprintf("smoketcp.%s", hostname))
+	s, err := statsd.Dial(os.Args[1], fmt.Sprintf("smoketcp.%s", hostname))
 	dieIfError(err)
 	bucket := os.Args[2]
 	defer s.Close()

--- a/smoketcp.go
+++ b/smoketcp.go
@@ -18,18 +18,18 @@ func dieIfError(err error) {
 	}
 }
 
-func doEvery(d time.Duration, f func(*statsd.Client, string, bool), s *statsd.Client, target_file string, debug bool) {
-	f(s, target_file, debug)
+func doEvery(d time.Duration, f func(*statsd.Client, string, bool), s *statsd.Client, targetFile string, debug bool) {
+	f(s, targetFile, debug)
 	for _ = range time.Tick(d) {
-		f(s, target_file, debug)
+		f(s, targetFile, debug)
 	}
 }
 
-func process_targets(s *statsd.Client, target_file string, debug bool) {
-	content, err := ioutil.ReadFile(target_file)
+func processTargets(s *statsd.Client, targetFile string, debug bool) {
+	content, err := ioutil.ReadFile(targetFile)
 	if err != nil {
 		if debug {
-			fmt.Println("couldn't open targets file:", target_file)
+			fmt.Println("couldn't open targets file:", targetFile)
 		}
 		return
 	}
@@ -67,16 +67,16 @@ func test(target string, s *statsd.Client, debug bool) {
 }
 
 func main() {
-	var statsd_host = flag.String("statsd_host", "localhost", "Statsd Hostname")
-	var statsd_port = flag.String("statsd_port", "8125", "Statsd port")
+	var statsdHost = flag.String("statsdHost", "localhost", "Statsd Hostname")
+	var statsdPort = flag.String("statsdPort", "8125", "Statsd port")
 	var bucket = flag.String("bucket", "smoketcp", "Graphite bucket prefix")
-	var target_file = flag.String("target_file", "targets", "File containing the list of targets, ex: server1:80")
+	var targetFile = flag.String("targetFile", "targets", "File containing the list of targets, ex: server1:80")
 	var debug = flag.Bool("debug", false, "if true, turn on debugging output")
 	var interval = flag.Int("interval", 10, "How often to run the tests")
 	flag.Parse()
 
-	s, err := statsd.Dial(fmt.Sprintf("%s:%s", *statsd_host, *statsd_port), fmt.Sprintf("%s", *bucket))
+	s, err := statsd.Dial(fmt.Sprintf("%s:%s", *statsdHost, *statsdPort), fmt.Sprintf("%s", *bucket))
 	dieIfError(err)
 	defer s.Close()
-	doEvery(time.Duration(*interval)*time.Second, process_targets, s, *target_file, *debug)
+	doEvery(time.Duration(*interval)*time.Second, processTargets, s, *targetFile, *debug)
 }


### PR DESCRIPTION
Rolls in all the changes from my previous pull request https://github.com/vimeo/smoketcp/pull/1 , plus adds command line flags, allowing configuration of where the targets file is, the interval, bucket, statsd_host, statsd_port, and debug.  

Debug will turn on output to stdout, like before, but by default it doesn't output anything to stdout
